### PR TITLE
Temporarily bypass next-seo

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -20,7 +20,16 @@ class MyDocument extends Document {
   render () {
     return (
       <Html>
-        <Head />
+        <Head>
+          {/* TODO: Figure out SSR/next-seo doesn't work */}
+          <meta property="og:url" content="https://writewithwrabit.com" class="next-head"/>
+          <meta property="og:type" content="website" class="next-head" />
+          <meta property="og:title" content="Write With Wrabit" class="next-head" />
+          <meta property="og:description" content="Wrabit helps you build a daily writing habit, one small step at a time. Join a community of others as you develop a healthier relationship with yourself." class="next-head" />
+          <meta property="og:image" content="https://writewithwrabit.com/static/og.png" class="next-head" />
+          <meta property="og:image:alt" content="Write With Wrabit" class="next-head" />
+          <meta property="og:site_name" content="Wrabit" class="next-head" />
+        </Head>
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
It turns out server side rendering isn't working properly. Because of this, `next-seo` doesn't work properly.

This PR manually adds some meta-tags so that I can utilize OpenGraph for the landing page launch.