### PR TITLE
Use new GraphQL query to get daily entry

### DIFF
--- a/pages/write.js
+++ b/pages/write.js
@@ -1,32 +1,37 @@
 import gql from "graphql-tag";
 import { useQuery } from '@apollo/react-hooks';
 import { useStoreState } from 'easy-peasy';
+import { startOfDay } from 'date-fns';
 
 import withLayout from '../components/Layout';
 
 import Editor from '../components/Editor';
 
 const GET_ENTRY = gql`
-  query LatestEntry($userID: ID!) {
-    latestEntry(userID: $userID) {
+  query DailyEntry($userID: ID!, $date: String!) {
+    dailyEntry(userID: $userID, date: $date) {
       id
       content
       wordCount
+      createdAt
     }
   }
 `;
 
 const Write = () => {
   const { uid: userID } = useStoreState(state => state.user).firebaseData;
+
+  const date = startOfDay(new Date());
+
   const { loading, error, data } = useQuery(GET_ENTRY, {
-    variables: { userID },
+    variables: { userID, date },
   });
 
   if (loading) return (<div>LOADING</div>);
   if (error) return (<div>ERROR</div>);
-
+  console.log(data);
   return (
-    <Editor entry={data.latestEntry} />
+    <Editor entry={data.dailyEntry} />
   );
 }
 


### PR DESCRIPTION
This PR resolves an issue where the daily entry wasn't actually based on midnight for a specific user's timezone. Now it does. This might cause some issues with user's who travel through timezones but if I end up having that problem then we probably have a healthy amount of users. 😄 