### PR TITLE
Add logic to handle creating writing streaks

### DIFF
--- a/components/Content.js
+++ b/components/Content.js
@@ -8,7 +8,7 @@ const Content = ({ entry }) => {
   try {
     jsonEntry = JSON.parse(entry.content)
   } catch(e) {
-    console.log('Invalid JSON passed, probably a new entry.');
+    // TODO: Handle this error
   }
 
   const initialValue = Value.fromJSON(jsonEntry);

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -36,12 +36,12 @@ const emptyDocument = {
 
 const DEFAULT_NODE = 'paragraph';
 
-const Editor = ({ entry }) => {
+const Editor = ({ entry, date }) => {
   let jsonEntry;
   try {
     jsonEntry = JSON.parse(entry.content)
   } catch(e) {
-    console.log('Invalid JSON passed, probably a new entry.');
+    // TODO: Handle this error?
   }
 
   const saveEntry = useStoreActions(actions => actions.editor.saveEntry);
@@ -52,7 +52,7 @@ const Editor = ({ entry }) => {
 
   const [value, setValue] = useState(initialValue); 
   
-  const goalWords = 1000;
+  const goalWords = 500;
   const [wordsWritten, setWordsWritten] = useState(0);
   const percentWordsRemaining = ((wordsWritten / goalWords) * 100).toFixed(2);
   const progressBarStyles = {
@@ -81,6 +81,8 @@ const Editor = ({ entry }) => {
       ...entry,
       content,
       wordCount,
+      goalHit: wordCount > goalWords,
+      date,
     });
   }
 

--- a/pages/write.js
+++ b/pages/write.js
@@ -29,9 +29,9 @@ const Write = () => {
 
   if (loading) return (<div>LOADING</div>);
   if (error) return (<div>ERROR</div>);
-  console.log(data);
+
   return (
-    <Editor entry={data.dailyEntry} />
+    <Editor entry={data.dailyEntry} date={date} />
   );
 }
 

--- a/store/editor.js
+++ b/store/editor.js
@@ -8,8 +8,8 @@ import init from '../lib/apollo/init';
 const apollo = init();
 
 const UPDATE_ENTRY = gql`
-  mutation UpdateEntry($id: ID!, $input: ExistingEntry!) {
-    updateEntry(id: $id, input: $input) {
+  mutation UpdateEntry($id: ID!, $input: ExistingEntry!, $date: String!) {
+    updateEntry(id: $id, input: $input, date: $date) {
       id
       content
       wordCount
@@ -18,7 +18,7 @@ const UPDATE_ENTRY = gql`
 `;
 
 const throttledSaveEntry = throttle(async (actions, payload) => {
-  const { id, content, wordCount, userID } = payload;
+  const { id, content, wordCount, userID, goalHit, date } = payload;
 
   await apollo.mutate({
     mutation: UPDATE_ENTRY,
@@ -28,7 +28,9 @@ const throttledSaveEntry = throttle(async (actions, payload) => {
         userID, 
         content,
         wordCount,
-      }
+        goalHit,
+      },
+      date,
     }
   });
 
@@ -46,9 +48,9 @@ const editor = {
     state.entry = payload;
   }),
   saveEntry: thunk((actions, payload) => {
-    const { id, content, wordCount } = payload;
+    const { id, content, wordCount, goalHit, date } = payload;
     const { uid: userID } = firebase.auth().currentUser;
-    throttledSaveEntry(actions, { id, content, wordCount, userID });
+    throttledSaveEntry(actions, { id, content, wordCount, userID, goalHit, date });
   }),
 };
 


### PR DESCRIPTION
This PR:
- [x] Cleans up some `console.log`s
- [x] Lowers the writing goal to 500 (until the goal comes from user settings)
- [x] Sends date and `goalHit` to the server

All of this allows streaks to get created on the server!