### PR TITLE
Dynamically load large components

### DIFF
--- a/pages/entries.js
+++ b/pages/entries.js
@@ -2,13 +2,17 @@ import { useState, useRef, Suspense } from 'react';
 import DayPicker, { DateUtils } from 'react-day-picker';
 import 'react-day-picker/lib/style.css';
 import { format } from 'date-fns';
+import dynamic from 'next/dynamic';
 
 import GetEntries from '../queries/GetEntries';
 
 import withLayout from '../components/Layout';
 import withPreloadedQuery from '../components/PreloadedQuery';
 import PageHeader from '../components/PageHeader';
-import EntriesList from '../components/EntriesList';
+const EntriesList = dynamic(
+  () => import('../components/EntriesList'),
+  { ssr: false }
+);
 
 const formatFriendly = date => format(new Date(date), 'MMMM d, yyyy');
 

--- a/pages/write.js
+++ b/pages/write.js
@@ -1,11 +1,15 @@
 import { Suspense } from 'react';
 import { startOfDay } from 'date-fns';
+import dynamic from 'next/dynamic';
 
 import GetEntry from '../queries/GetEntry';
 
 import withLayout from '../components/Layout';
 import withPreloadedQuery from '../components/PreloadedQuery';
-import Editor from '../components/Editor';
+const Editor = dynamic(
+  () => import('../components/Editor'),
+  { ssr: false }
+);
 
 const Write = () => (
   <Suspense fallback={<div>Loading...</div>}>


### PR DESCRIPTION
This PR:
- [x] Dynamically loads hefty components (`Editor`, `EntriesList`) which use Relay to fetch data

Pre-Dynamic Load:
```bash
Page            Size     Files  Packages
┌ ⚡ /           533 kB      26        23
├   /_app       1.24 MB      0        24
├   /_document
├   /_error     7.13 kB      0        21
├ ⚡ /about      368 B       10        21
├ ⚡ /entries    404 kB      22        50
├ ⚡ /login      2.31 kB     10        21
├ ⚡ /settings   714 B       11        21
├ ⚡ /signup     60.8 kB     15        22
├ ⚡ /stats      7.94 kB     20        22
└ ⚡ /write      341 kB      14        48
```

Post-Dynamic Load:
```bash
Page            Size     Files  Packages
┌ ⚡ /           533 kB      26        23
├   /_app       1.24 MB      0        24
├   /_document
├   /_error     7.13 kB      0        21
├ ⚡ /about      368 B       10        21
├ ⚡ /entries    70.5 kB     22        50
├ ⚡ /login      2.31 kB     10        21
├ ⚡ /settings   714 B       11        21
├ ⚡ /signup     60.8 kB     15        22
├ ⚡ /stats      7.94 kB     20        22
└ ⚡ /write      8.68 kB     14        48
```

Obviously there are more improvements to be done but it's a start.