### PR TITLE
Add the ability to cancel/resubscribe to a plan

### DIFF
--- a/components/Plans.js
+++ b/components/Plans.js
@@ -1,6 +1,10 @@
+import { useStoreActions } from 'easy-peasy';
+
 import Payment from './Payment';
 
 const Plans = ({ setPlan, plan, user }) => {
+  const completeUserSignup = useStoreActions(actions => actions.user.completeUserSignup);
+
   return (
     <div className="flex flex-col items-center pt-16">
       <div className="text-center pb-6 text-5xl font-extrabold">
@@ -30,7 +34,7 @@ const Plans = ({ setPlan, plan, user }) => {
 
           {
             plan === 'monthly'
-              ? <Payment user={user} plan="plan_FsvZtUpz9xw0Tx" />
+              ? <Payment user={user} plan="plan_FsvZtUpz9xw0Tx" onCompleted={completeUserSignup} />
               : (
                 <button
                   className="text-blue-500 hover:text-blue-700 font-bold p-4 mt-6 rounded border-blue-500 border-2 hover:border-blue-700 focus:outline-none focus:shadow-outline w-full"

--- a/components/SubscriptionSettings.js
+++ b/components/SubscriptionSettings.js
@@ -1,66 +1,116 @@
-import { graphql, useLazyLoadQuery } from 'react-relay/hooks';
-import { formatDistance, fromUnixTime } from 'date-fns'
+import { useState } from 'react';
+import { useLazyLoadQuery } from 'react-relay/hooks';
+import { commitMutation } from 'react-relay';
+import { formatDistance, fromUnixTime } from 'date-fns';
+import Head from 'next/head';
 
-const GET_USER_SUBSCRIPTION = graphql`
-  query SubscriptionSettingsQuery($firebaseID: String!) {
-    userByFirebaseID(firebaseID: $firebaseID) {
-      StripeSubscription {
-        id
-        currentPeriodEnd
-        trialEnd
-        cancelAt
-        status
-        plan {
-          id
-          nickname
-          product
-        }
-      }
-    }
+import GET_USER_SUBSCRIPTION from '../queries/GetUserSubscription';
+import CANCEL_SUBSCRIPTION from '../queries/CancelSubscription';
+
+import createRelayEnvironment from '../lib/relay/createRelayEnvironment';
+
+const environment = createRelayEnvironment();
+
+import Payment from '../components/Payment';
+
+const buttonClasses = 'font-semibold py-2 px-4 border rounded';
+
+const CancelSubscriptionButton = ({ subscription, setSubscription }) => {
+  const cancelSubscription = () => {
+    commitMutation(environment, {
+      mutation: CANCEL_SUBSCRIPTION,
+      variables: {
+        subscriptionID: subscription.id,
+      },
+      onCompleted: () => setSubscription({ ...subscription, status: 'canceled' }),
+    });
   }
-`;
+
+  return (
+    <button
+      className={`${buttonClasses} bg-transparent hover:bg-red-500 text-red-700 hover:text-white border-red-500 hover:border-transparent`}
+      onClick={cancelSubscription}
+    >
+      Cancel
+    </button>
+  );
+}
+
+const ResubscribeButton = ({ plan, user, setSubscription }) => {
+  const [showPayment, setShowPayment] = useState(false);
+
+  return (
+    <>
+    {
+      showPayment
+        ? <Payment user={user} plan={plan} trial={false} onCompleted={({ subscription }) => setSubscription(subscription)} />
+        : (
+          <button
+            className={`${buttonClasses} bg-primary hover:bg-primary-dark text-white border-primary`}
+            onClick={() => setShowPayment(true)}
+          >
+            Resubscribe
+          </button>
+        )
+    }
+    </>
+  );
+}
 
 const SubscriptionSettings = ({ user }) => {
   const { userByFirebaseID } = useLazyLoadQuery(GET_USER_SUBSCRIPTION, {
     firebaseID: user.firebaseData.uid,
   });
+  const { stripeID, StripeSubscription } = userByFirebaseID;
+  const [subscription, setSubscription] = useState(StripeSubscription);
+  const { status } = subscription;
 
-  const { StripeSubscription } = userByFirebaseID;
-  const isTrial = StripeSubscription.status === 'trialing';
+  const isTrial = status === 'trialing';
+  const isCanceled = status === 'canceled';
+  
+  let periodText = 'Next Billing Date';
+  if (isTrial) {
+    periodText = 'Trial Ends';
+  } else if (isCanceled) {
+    periodText = 'Subscription Ends'
+  }
 
   return (
     <div>
+      {
+        isCanceled && (
+          <Head>
+            {/* You must import the Stripe.js library from Stripe for compliance reasons */}
+            <script src="https://js.stripe.com/v3/"></script>
+          </Head>
+        )
+      }
+
       <div className="mb-8">
         <div className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2">
-          Plan
+          Plan {isCanceled && <span className="text-xs font-semibold text-red-600">(Canceled)</span>}
         </div>
 
-        {StripeSubscription.plan.nickname}
+        {subscription.plan.nickname}
       </div>
 
       <div className="mb-8">
         <div className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2">
-          {
-            isTrial
-              ? 'Trial Ends'
-              : 'Next Billing Date'
-          }
+          {periodText}
         </div>
 
         {
           isTrial
-            ? formatDistance(new Date(), fromUnixTime(StripeSubscription.trialEnd))
-            : formatDistance(new Date(), fromUnixTime(StripeSubscription.currentPeriodEnd))
+            ? formatDistance(new Date(), fromUnixTime(subscription.trialEnd))
+            : formatDistance(new Date(), fromUnixTime(subscription.currentPeriodEnd))
         }
       </div>
 
-      {/* <button disabled className="bg-transparent hover:bg-red-500 text-red-700 font-semibold hover:text-white py-2 px-4 border border-red-500 hover:border-transparent rounded">
-        {
-          StripeSubscription.status === 'canceled'
-            ? 'Restart'
-            : 'Cancel'
-        }
-      </button> */}
+      {
+        isCanceled
+          ? <ResubscribeButton plan={subscription.plan.id} user={{ ...user, stripeId: stripeID }} setSubscription={setSubscription} />
+          : <CancelSubscriptionButton subscription={subscription} setSubscription={setSubscription} />
+      }
     </div>
   );
 }

--- a/components/__generated__/PaymentQuery.graphql.js
+++ b/components/__generated__/PaymentQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash c371391afc5d39aff4e37a86c2f7e7cc
+ * @relayHash ae3e0540358e15826a06cebb60d71a94
  */
 
 /* eslint-disable */
@@ -18,7 +18,18 @@ export type PaymentQueryVariables = {|
   input: NewSubscription
 |};
 export type PaymentQueryResponse = {|
-  +createSubscription: string
+  +createSubscription: {|
+    +id: string,
+    +currentPeriodEnd: number,
+    +trialEnd: number,
+    +cancelAt: number,
+    +status: string,
+    +plan: {|
+      +id: string,
+      +nickname: string,
+      +product: string,
+    |},
+  |}
 |};
 export type PaymentQuery = {|
   variables: PaymentQueryVariables,
@@ -31,7 +42,18 @@ export type PaymentQuery = {|
 mutation PaymentQuery(
   $input: NewSubscription!
 ) {
-  createSubscription(input: $input)
+  createSubscription(input: $input) {
+    id
+    currentPeriodEnd
+    trialEnd
+    cancelAt
+    status
+    plan {
+      id
+      nickname
+      product
+    }
+  }
 }
 */
 
@@ -44,11 +66,19 @@ var v0 = [
     "defaultValue": null
   }
 ],
-v1 = [
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v2 = [
   {
-    "kind": "ScalarField",
+    "kind": "LinkedField",
     "alias": null,
     "name": "createSubscription",
+    "storageKey": null,
     "args": [
       {
         "kind": "Variable",
@@ -56,7 +86,65 @@ v1 = [
         "variableName": "input"
       }
     ],
-    "storageKey": null
+    "concreteType": "StripeSubscription",
+    "plural": false,
+    "selections": [
+      (v1/*: any*/),
+      {
+        "kind": "ScalarField",
+        "alias": null,
+        "name": "currentPeriodEnd",
+        "args": null,
+        "storageKey": null
+      },
+      {
+        "kind": "ScalarField",
+        "alias": null,
+        "name": "trialEnd",
+        "args": null,
+        "storageKey": null
+      },
+      {
+        "kind": "ScalarField",
+        "alias": null,
+        "name": "cancelAt",
+        "args": null,
+        "storageKey": null
+      },
+      {
+        "kind": "ScalarField",
+        "alias": null,
+        "name": "status",
+        "args": null,
+        "storageKey": null
+      },
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "plan",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Plan",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "nickname",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "product",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
   }
 ];
 return {
@@ -67,23 +155,23 @@ return {
     "type": "Mutation",
     "metadata": null,
     "argumentDefinitions": (v0/*: any*/),
-    "selections": (v1/*: any*/)
+    "selections": (v2/*: any*/)
   },
   "operation": {
     "kind": "Operation",
     "name": "PaymentQuery",
     "argumentDefinitions": (v0/*: any*/),
-    "selections": (v1/*: any*/)
+    "selections": (v2/*: any*/)
   },
   "params": {
     "operationKind": "mutation",
     "name": "PaymentQuery",
     "id": null,
-    "text": "mutation PaymentQuery(\n  $input: NewSubscription!\n) {\n  createSubscription(input: $input)\n}\n",
+    "text": "mutation PaymentQuery(\n  $input: NewSubscription!\n) {\n  createSubscription(input: $input) {\n    id\n    currentPeriodEnd\n    trialEnd\n    cancelAt\n    status\n    plan {\n      id\n      nickname\n      product\n    }\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
 // prettier-ignore
-(node/*: any*/).hash = '9a3cc14f0c733b8dd44e48890d91afe6';
+(node/*: any*/).hash = '5dde56a7dc51d9b523c42bb70d6d4c20';
 module.exports = node;

--- a/queries/CancelSubscription.js
+++ b/queries/CancelSubscription.js
@@ -1,0 +1,9 @@
+import { graphql } from 'react-relay/hooks';
+
+const CancelSubscription = graphql`
+  mutation CancelSubscriptionQuery($subscriptionID: ID!) {
+    cancelSubscription(id: $subscriptionID)
+  }
+`;
+
+export default CancelSubscription;

--- a/queries/GetUserSubscription.js
+++ b/queries/GetUserSubscription.js
@@ -1,0 +1,22 @@
+import { graphql } from 'react-relay/hooks';
+
+const GetUserSubscription = graphql`
+query GetUserSubscriptionQuery($firebaseID: String!) {
+  userByFirebaseID(firebaseID: $firebaseID) {
+    stripeID
+    StripeSubscription {
+      id
+      currentPeriodEnd
+      trialEnd
+      cancelAt
+      status
+      plan {
+        id
+        nickname
+        product
+      }
+    }
+  }
+}`;
+
+export default GetUserSubscription;

--- a/queries/__generated__/CancelSubscriptionQuery.graphql.js
+++ b/queries/__generated__/CancelSubscriptionQuery.graphql.js
@@ -1,0 +1,84 @@
+/**
+ * @flow
+ * @relayHash c6aa52acf8e55a433430f1b4eb1d4768
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest } from 'relay-runtime';
+export type CancelSubscriptionQueryVariables = {|
+  subscriptionID: string
+|};
+export type CancelSubscriptionQueryResponse = {|
+  +cancelSubscription: string
+|};
+export type CancelSubscriptionQuery = {|
+  variables: CancelSubscriptionQueryVariables,
+  response: CancelSubscriptionQueryResponse,
+|};
+*/
+
+
+/*
+mutation CancelSubscriptionQuery(
+  $subscriptionID: ID!
+) {
+  cancelSubscription(id: $subscriptionID)
+}
+*/
+
+const node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "subscriptionID",
+    "type": "ID!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "cancelSubscription",
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "id",
+        "variableName": "subscriptionID"
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "CancelSubscriptionQuery",
+    "type": "Mutation",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": (v1/*: any*/)
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "CancelSubscriptionQuery",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "operationKind": "mutation",
+    "name": "CancelSubscriptionQuery",
+    "id": null,
+    "text": "mutation CancelSubscriptionQuery(\n  $subscriptionID: ID!\n) {\n  cancelSubscription(id: $subscriptionID)\n}\n",
+    "metadata": {}
+  }
+};
+})();
+// prettier-ignore
+(node/*: any*/).hash = 'a5b3c8fb1941fbc30f0c7d5519bfd707';
+module.exports = node;

--- a/queries/__generated__/GetUserSubscriptionQuery.graphql.js
+++ b/queries/__generated__/GetUserSubscriptionQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 6e0b810061e57d42b11a204456b97db0
+ * @relayHash 64cfc80752cd7a5362078190616acfb7
  */
 
 /* eslint-disable */
@@ -9,11 +9,12 @@
 
 /*::
 import type { ConcreteRequest } from 'relay-runtime';
-export type SubscriptionSettingsQueryVariables = {|
+export type GetUserSubscriptionQueryVariables = {|
   firebaseID: string
 |};
-export type SubscriptionSettingsQueryResponse = {|
+export type GetUserSubscriptionQueryResponse = {|
   +userByFirebaseID: {|
+    +stripeID: ?string,
     +StripeSubscription: ?{|
       +id: string,
       +currentPeriodEnd: number,
@@ -25,21 +26,22 @@ export type SubscriptionSettingsQueryResponse = {|
         +nickname: string,
         +product: string,
       |},
-    |}
+    |},
   |}
 |};
-export type SubscriptionSettingsQuery = {|
-  variables: SubscriptionSettingsQueryVariables,
-  response: SubscriptionSettingsQueryResponse,
+export type GetUserSubscriptionQuery = {|
+  variables: GetUserSubscriptionQueryVariables,
+  response: GetUserSubscriptionQueryResponse,
 |};
 */
 
 
 /*
-query SubscriptionSettingsQuery(
+query GetUserSubscriptionQuery(
   $firebaseID: String!
 ) {
   userByFirebaseID(firebaseID: $firebaseID) {
+    stripeID
     StripeSubscription {
       id
       currentPeriodEnd
@@ -76,11 +78,18 @@ v1 = [
 v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "stripeID",
   "args": null,
   "storageKey": null
 },
 v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "StripeSubscription",
@@ -89,7 +98,7 @@ v3 = {
   "concreteType": "StripeSubscription",
   "plural": false,
   "selections": [
-    (v2/*: any*/),
+    (v3/*: any*/),
     {
       "kind": "ScalarField",
       "alias": null,
@@ -127,7 +136,7 @@ v3 = {
       "concreteType": "Plan",
       "plural": false,
       "selections": [
-        (v2/*: any*/),
+        (v3/*: any*/),
         {
           "kind": "ScalarField",
           "alias": null,
@@ -150,7 +159,7 @@ return {
   "kind": "Request",
   "fragment": {
     "kind": "Fragment",
-    "name": "SubscriptionSettingsQuery",
+    "name": "GetUserSubscriptionQuery",
     "type": "Query",
     "metadata": null,
     "argumentDefinitions": (v0/*: any*/),
@@ -164,14 +173,15 @@ return {
         "concreteType": "User",
         "plural": false,
         "selections": [
-          (v3/*: any*/)
+          (v2/*: any*/),
+          (v4/*: any*/)
         ]
       }
     ]
   },
   "operation": {
     "kind": "Operation",
-    "name": "SubscriptionSettingsQuery",
+    "name": "GetUserSubscriptionQuery",
     "argumentDefinitions": (v0/*: any*/),
     "selections": [
       {
@@ -183,21 +193,22 @@ return {
         "concreteType": "User",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
-          (v2/*: any*/)
+          (v2/*: any*/),
+          (v4/*: any*/),
+          (v3/*: any*/)
         ]
       }
     ]
   },
   "params": {
     "operationKind": "query",
-    "name": "SubscriptionSettingsQuery",
+    "name": "GetUserSubscriptionQuery",
     "id": null,
-    "text": "query SubscriptionSettingsQuery(\n  $firebaseID: String!\n) {\n  userByFirebaseID(firebaseID: $firebaseID) {\n    StripeSubscription {\n      id\n      currentPeriodEnd\n      trialEnd\n      cancelAt\n      status\n      plan {\n        id\n        nickname\n        product\n      }\n    }\n    id\n  }\n}\n",
+    "text": "query GetUserSubscriptionQuery(\n  $firebaseID: String!\n) {\n  userByFirebaseID(firebaseID: $firebaseID) {\n    stripeID\n    StripeSubscription {\n      id\n      currentPeriodEnd\n      trialEnd\n      cancelAt\n      status\n      plan {\n        id\n        nickname\n        product\n      }\n    }\n    id\n  }\n}\n",
     "metadata": {}
   }
 };
 })();
 // prettier-ignore
-(node/*: any*/).hash = '9ff8b82ebe396387a769f2f32ab2c617';
+(node/*: any*/).hash = '8bcd8a4ac4a3530c681bec42a0fc852c';
 module.exports = node;

--- a/schema.graphql
+++ b/schema.graphql
@@ -34,7 +34,8 @@ type Mutation {
   createEntry(input: NewEntry!): Entry!
   updateEntry(id: ID!, input: ExistingEntry!, date: String!): Entry!
   createEditor(input: NewEditor!): Editor!
-  createSubscription(input: NewSubscription!): String!
+  createSubscription(input: NewSubscription!): StripeSubscription!
+  cancelSubscription(id: ID!): String!
 }
 
 input NewEditor {


### PR DESCRIPTION
This PR:
- [x] Gives users the ability to cancel a subscription
- [x] Gives users the ability to resubscribe after they have cancelled
- [x] Refactors `Payment` component to be more reusable
- [x] Refactors the `GET_USER_SUBSCRIPTION` query to be in its own file