### PR TITLE
Add a 404 page and enhance the global error boundary

### DIFF
--- a/components/GlobalErrorBoundary.js
+++ b/components/GlobalErrorBoundary.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({ dsn: process.env.SENTRY_DSN });
 
 const errorFaces = [
   {
@@ -39,6 +42,16 @@ class ErrorBoundary extends React.Component {
       error,
       errorInfo,
     });
+
+    Sentry.withScope(scope => {
+      Object.keys(errorInfo).forEach(key => {
+        scope.setExtra(key, errorInfo[key])
+      });
+
+      Sentry.captureException(error);
+    });
+
+    super.componentDidCatch(error, errorInfo);
   }
 
   render() {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -48,10 +48,8 @@ class WrabitDocument extends Document {
           <link rel="icon" type="image/png" sizes="32x32" href="favicons/favicon-32x32.png" />
           <link rel="icon" type="image/png" sizes="96x96" href="favicons/favicon-96x96.png" />
           <link rel="icon" type="image/png" sizes="16x16" href="favicons/favicon-16x16.png" />
-          <link rel="manifest" href="/manifest.json" />
-          <meta name="msapplication-TileColor" content="#ffffff" />
-          <meta name="msapplication-TileImage" content="/ms-icon-144x144.png" />
-          <meta name="theme-color" content="#ffffff"></meta>
+          <link rel="manifest" href="favicons/manifest.json" />
+          <meta name="msapplication-TileImage" content="favicons/ms-icon-144x144.png" />
         </Head>
 
         <body>

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,7 +1,8 @@
+import Link from 'next/link';
+
 import GlobalErrorBoundary from '../components/GlobalErrorBoundary';
 
 const NotFound = ({ statusCode }) => {
-  console.log(statusCode);
   if (statusCode !== 404 && statusCode !== 200) {
     throw('Something went wrong...');
   }
@@ -12,6 +13,10 @@ const NotFound = ({ statusCode }) => {
 
       <div>
         That's odd, I couldn't find what you were looking for.
+      </div>
+
+      <div>
+        Why don't we <Link href="/"><a>head back to the homepage?</a></Link>
       </div>
     </div>
   );

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,5 +1,34 @@
 import GlobalErrorBoundary from '../components/GlobalErrorBoundary';
 
-const Error = () => <GlobalErrorBoundary />
+const NotFound = ({ statusCode }) => {
+  console.log(statusCode);
+  if (statusCode !== 404 && statusCode !== 200) {
+    throw('Something went wrong...');
+  }
+
+  return (
+    <div className="flex flex-col justify-center items-center text-xl min-h-screen" >
+      <img className="w-1/5 " src="/memojis/embarrassed.png" alt="rabbit embarrassed" />
+
+      <div>
+        That's odd, I couldn't find what you were looking for.
+      </div>
+    </div>
+  );
+}
+
+const Error = ({ statusCode }) => {
+
+  return (
+    <GlobalErrorBoundary>
+      <NotFound statusCode={statusCode} />
+    </GlobalErrorBoundary>
+  );
+}
+
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404
+  return { statusCode }
+}
 
 export default Error;


### PR DESCRIPTION
This PR:
- [x] Handles 404s
- [x] Sents errors to Sentry when the `GlobalErrorBoundary` catches
- [x] Resolves #80 